### PR TITLE
remove deprecated plugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,7 +64,7 @@ module.exports = {
   devtool: 'eval-source-map',
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
+    new webpack.NoEmitOnErrorsPlugin()
   ],
   module: {
     loaders: [


### PR DESCRIPTION
`webpack.NoErrorsPlugin()` throws a deprecation notice. Changed it out for `webpack.NoEmitOnErrorsPlugin()`